### PR TITLE
Use DejaVu Sans fonts

### DIFF
--- a/site/assets/css/fish_style.css
+++ b/site/assets/css/fish_style.css
@@ -119,7 +119,7 @@ ul li {
 }
 
 .mono {
-	font-family: Courier, "Courier New", monospace;
+	font-family: Menlo, Monaco, "DejaVu Sans Mono", "Courier New", Courier, monospace;
 	font-size: 11pt;
 }
 

--- a/site/tutorial.html
+++ b/site/tutorial.html
@@ -14,7 +14,7 @@ pre {
 	color: white;
 	padding: 10px 12px;
 	font-size: 10pt;
-	font-family: Menlo, Monaco, Courier, monospace;
+	font-family: Menlo, Monaco, "DejaVu Sans Mono", "Courier New", Courier, monospace;
 	line-height: 140%;
 	white-space: pre-wrap;
 	margin-top: 10px;


### PR DESCRIPTION
Courier which is used on this website (if you have Wine installed, which lets you run Windows programs) is the ugly font (and I hate it). This pull request uses DejaVu Sans Mono if possible, instead of Courier, which is in my opinion way better font.

This font exists in most Linux distributions.

![DejaVu Sans Mono](https://upload.wikimedia.org/wikipedia/commons/b/b9/DejaVu_Sans_Mono.svg)
