### PR TITLE
Add reference to official Fedora packages on home page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -208,9 +208,9 @@
         <div>
           <p><img src="assets/img/fed_icon.png" alt="Fedora"></p>
 
-          <p><a class="tab_link" href="files/2.1.0/linux/Fedora_18/fish-2.1.0-2.1.i686.rpm" title="SHA1: 5c648db85578812b97127b6f4a9537c7dfcb295b">32-bit</a> | <a class="tab_link" href="files/2.1.0/linux/Fedora_18/fish-2.1.0-2.1.x86_64.rpm" title="SHA1: e8ee306d41017302338dc3a959e936835d0e48e2">64-bit</a></p>
+          <p><a href="https://apps.fedoraproject.org/packages/fish">Packages</a></p>
 
-          <p><a href="files/2.1.0/linux/index.html#dl-fedora18">How to Subscribe</a></p>
+          <p style="margin-bottom: 11px"><small><span class="mono" style="font-size: 11pt">yum install fish</span></small></p>
         </div>
 
         <div>


### PR DESCRIPTION
I didn't update http://fishshell.com/files/2.1.0/linux/index.html because it doesn't seem to live in this repo.