### PR TITLE
Replace sf.net with sourceforge.net

### DIFF
--- a/site/docs/2.0/index.html
+++ b/site/docs/2.0/index.html
@@ -529,7 +529,7 @@ Once you have provided a translation for fish, please submit it via the instruct
 Further help and development</a></h2>
 If you have a question not answered by this documentation, there are several avenues for help:<p>
 <ol type=1>
-<li>The official mailing list at <a href="fish-users@lists.sf.net">fish-users@lists.sf.net</a></li><li>The Internet Relay Chat channel, <code>fish</code> on <code>irc.oftc.net</code> </li><li>The <a href="http://github.com/fish-shell/fish-shell/">project GitHub page</a></li></ol>
+<li>The official mailing list at <a href="fish-users@lists.sourceforge.net">fish-users@lists.sourceforge.net</a></li><li>The Internet Relay Chat channel, <code>fish</code> on <code>irc.oftc.net</code> </li><li>The <a href="http://github.com/fish-shell/fish-shell/">project GitHub page</a></li></ol>
 <p>
 If you have an improvement for fish, you can submit it via the mailing list or the GitHub page. </div>
 <hr size="1"><address style="text-align: right;"><small>Generated on Thu May 16 09:27:19 2013 for fish by&nbsp;

--- a/site/docs/2.1/index.html
+++ b/site/docs/2.1/index.html
@@ -877,7 +877,7 @@ Common issues with fish</h1>
 Further help and development</h1>
 <p>If you have a question not answered by this documentation, there are several avenues for help:</p>
 <ol type="1">
-<li>The official mailing list at <a href="fish-users@lists.sf.net">fish-users@lists.sf.net</a></li>
+<li>The official mailing list at <a href="fish-users@lists.sourceforge.net">fish-users@lists.sourceforge.net</a></li>
 <li>The Internet Relay Chat channel, <code>#fish</code> on <code>irc.oftc.net</code> </li>
 <li>The <a href="http://github.com/fish-shell/fish-shell/">project GitHub page</a></li>
 </ol>

--- a/site/docs/2.2/index.html
+++ b/site/docs/2.2/index.html
@@ -941,7 +941,7 @@ Common issues with fish</h1>
 Further help and development</h1>
 <p>If you have a question not answered by this documentation, there are several avenues for help:</p>
 <ol type="1">
-<li>The official mailing list at <a href="https://lists.sf.net/lists/listinfo/fish-users">fish-users@lists.sf.net</a></li>
+<li>The official mailing list at <a href="https://lists.sourceforge.net/lists/listinfo/fish-users">fish-users@lists.sourceforge.net</a></li>
 <li>The Internet Relay Chat channel, #fish on <code>irc.oftc.net</code></li>
 <li>The <a href="https://github.com/fish-shell/fish-shell/">project GitHub page</a></li>
 </ol>

--- a/site/docs/current/index.html
+++ b/site/docs/current/index.html
@@ -941,7 +941,7 @@ Common issues with fish</h1>
 Further help and development</h1>
 <p>If you have a question not answered by this documentation, there are several avenues for help:</p>
 <ol type="1">
-<li>The official mailing list at <a href="https://lists.sf.net/lists/listinfo/fish-users">fish-users@lists.sf.net</a></li>
+<li>The official mailing list at <a href="https://lists.sourceforge.net/lists/listinfo/fish-users">fish-users@lists.sourceforge.net</a></li>
 <li>The Internet Relay Chat channel, #fish on <code>irc.oftc.net</code></li>
 <li>The <a href="https://github.com/fish-shell/fish-shell/">project GitHub page</a></li>
 </ol>


### PR DESCRIPTION
When I clicked on the link to signup for the mailing list Google Chrome
told me "Your connection is not private". That's because their SSL cert
is signed for *.sourceforge.net rather than *.sf.net. Yes, SourceForge
should have a separate cert for the sf.net domain but they don't and I
doubt they're going to fix it anytime soon.