### PR TITLE
Remove text-rendering: optimizeLegibility

### DIFF
--- a/site/docs/2.2/user_doc.css
+++ b/site/docs/2.2/user_doc.css
@@ -9,7 +9,6 @@ html, body {
     color: #111;
 }
 body {
-    text-rendering: optimizeLegibility;
     overflow: hidden;
 }
 .logo {
@@ -271,5 +270,3 @@ tt, code, pre, .fish {
     position: absolute;
     left: -2rem;
 }
-
-

--- a/site/docs/2.3/user_doc.css
+++ b/site/docs/2.3/user_doc.css
@@ -9,7 +9,6 @@ html, body {
     color: #111;
 }
 body {
-    text-rendering: optimizeLegibility;
     overflow: hidden;
 }
 .logo {
@@ -271,5 +270,3 @@ tt, code, pre, .fish {
     position: absolute;
     left: -2rem;
 }
-
-

--- a/site/docs/current/user_doc.css
+++ b/site/docs/current/user_doc.css
@@ -9,7 +9,6 @@ html, body {
     color: #111;
 }
 body {
-    text-rendering: optimizeLegibility;
     overflow: hidden;
 }
 .logo {
@@ -271,5 +270,3 @@ tt, code, pre, .fish {
     position: absolute;
     left: -2rem;
 }
-
-


### PR DESCRIPTION
This causes overlapping text for inline <code> in Chrome on Android

Fixes #34 

You can look at this from a mobile device at https://storage.googleapis.com/fish-test-123/5/tutorial.html 