### PR TITLE
-l parameter confuses beginner

### DIFF
--- a/site/docs/current/tutorial.html
+++ b/site/docs/current/tutorial.html
@@ -288,8 +288,8 @@ Lists</h1>
 </pre><p>Lists adjacent to other lists or strings are expanded as <a href="index.html#cartesian-product">cartesian products</a> unless quoted (see <a href="index.html#expand-variable">Variable expansion</a>):</p>
  
  <pre class="fish cli-dark">
-<span class="prompt">&gt;</span> <span class="command">set</span> <span class="argument">-l</span> <span class="argument">a</span> <span class="argument">1</span> <span class="argument">2</span> <span class="argument">3</span>
-<span class="prompt">&gt;</span> <span class="command">set</span> <span class="argument">-l</span> <span class="argument">1</span> <span class="argument">a</span> <span class="argument">b</span> <span class="argument">c</span>
+<span class="prompt">&gt;</span> <span class="command">set</span> <span class="argument">a</span> <span class="argument">1</span> <span class="argument">2</span> <span class="argument">3</span>
+<span class="prompt">&gt;</span> <span class="command">set</span> <span class="argument">1</span> <span class="argument">a</span> <span class="argument">b</span> <span class="argument">c</span>
 <span class="prompt">&gt;</span> <span class="command">echo</span> <span class="variable"><span class="operator">$</span>a</span><span class="variable"><span class="operator">$</span>1</span>
 <span class="output">1a 2a 3a 1b 2b 3b 1c 2c 3c</span>
 <span class="prompt">&gt;</span> <span class="command">echo</span> <span class="variable"><span class="operator">$</span>a</span><span class="string">" banana"</span>


### PR DESCRIPTION
Because -l parameter is for local variable. When i've read this tutorial, i thought we can make list with -l parameter.

```fish
$ vim example.fish
set a 1 2 3
echo $a
function co
  set -l username $argv[1]
  echo "Username: $username"
end
co "Fish"
echo $username
$ fish example.fish
1 2 3
Username: Fish

$
```