### PR TITLE
Fix Windows Subsystem for Linux link

### DIFF
--- a/site/_site/index.html
+++ b/site/_site/index.html
@@ -424,11 +424,11 @@
 
       <div>
         <h4>
-          <a class="tab_link" href="https://docs.microsoft.com/de-de/windows/wsl/install-win10">Windows Subsystem for Linux</a>
+          <a class="tab_link" href="https://docs.microsoft.com/en-us/windows/wsl/install-win10">Windows Subsystem for Linux</a>
         </h4>
 
         <p>
-          <a class="tab_link" href="https://docs.microsoft.com/de-de/windows/wsl/install-win10">
+          <a class="tab_link" href="https://docs.microsoft.com/en-us/windows/wsl/install-win10">
             <img src="assets/img/win_icon.png" alt="Windows">
           </a>
         </p>

--- a/site/index.html
+++ b/site/index.html
@@ -427,11 +427,11 @@ title: fish shell
 
       <div>
         <h4>
-          <a class="tab_link" href="https://docs.microsoft.com/de-de/windows/wsl/install-win10">Windows Subsystem for Linux</a>
+          <a class="tab_link" href="https://docs.microsoft.com/en-us/windows/wsl/install-win10">Windows Subsystem for Linux</a>
         </h4>
 
         <p>
-          <a class="tab_link" href="https://docs.microsoft.com/de-de/windows/wsl/install-win10">
+          <a class="tab_link" href="https://docs.microsoft.com/en-us/windows/wsl/install-win10">
             <img src="assets/img/win_icon.png" alt="Windows">
           </a>
         </p>


### PR DESCRIPTION
A quick follow-up of #72.
The Windows Subsystem for Linux link should of course link to the English page, not the German one.