### PR TITLE
Add brew installation for Linux

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -385,7 +385,20 @@ title: fish shell
           </small>
         </p>
       </div>
+      <div>
+          <p>
+            <img src="assets/img/brew_icon.png" alt="Brew Icon">
+          </p>
+          <p>
+            <a href="https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/fish.rb">Homebrew</a>
+          </p>
 
+          <p>
+            <small>
+              <span class="mono">brew install fish</span>
+            </small>
+          </p>
+        </div>
     </div>
 
     <div class="download_tab tab-pane" id="get_fish_bsd">


### PR DESCRIPTION
Homebrew also officially supports Linux since 2.0.0 release, so I think it would be appropriate to add brew installation instructions to Linux tab too.

![image](https://user-images.githubusercontent.com/9713907/62423864-e8619580-b6c6-11e9-8d07-38e8b1340d71.png)
