### PR TITLE
Update fedora installation information

### DIFF
--- a/site/_site/index.html
+++ b/site/_site/index.html
@@ -263,9 +263,13 @@
         </p>
 
         <p>
-          <a href="https://software.opensuse.org/download.html?project=shells%3Afish%3Arelease%3A3&package=fish">
-            Subscribe or Download
-          </a>
+          <a href="https://apps.fedoraproject.org/packages/fish">Packages</a>
+        </p>
+	      
+	<p>
+          <small>
+            <span class="mono">dnf install fish</span>
+          </small>
         </p>
       </div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -266,9 +266,13 @@ title: fish shell
         </p>
 
         <p>
-          <a href="https://software.opensuse.org/download.html?project=shells%3Afish%3Arelease%3A3&package=fish">
-            Subscribe or Download
-          </a>
+          <a href="https://apps.fedoraproject.org/packages/fish">Packages</a>
+        </p>
+
+        <p>
+          <small>
+            <span class="mono">dnf install fish</span>
+          </small>
         </p>
       </div>
 


### PR DESCRIPTION
The fish packages were included for Fedora 30+ repositories 