### PR TITLE
Fix source tar build command

### DIFF
--- a/site/_site/index.html
+++ b/site/_site/index.html
@@ -477,7 +477,7 @@
 
         <p>
           <small>
-            <span class="mono">./configure; make; sudo make install</span>
+            <span class="mono">cmake .; make; sudo make install</span>
           </small>
         </p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -480,7 +480,7 @@ title: fish shell
 
         <p>
           <small>
-            <span class="mono">./configure; make; sudo make install</span>
+            <span class="mono">cmake .; make; sudo make install</span>
           </small>
         </p>
 


### PR DESCRIPTION
The command to build the source from a tarball says to run `./configure` that appears to be outdated (and not work) now that CMake is used.