### PR TITLE
[Fix] installation instruction for Debian

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -254,9 +254,13 @@ title: fish shell
         </p>
 
         <p>
-          <a href="https://software.opensuse.org/download.html?project=shells%3Afish%3Arelease%3A3&package=fish">
-            Subscribe or Download
-          </a>
+          <a href="https://tracker.debian.org/pkg/fish">Packages</a>
+        </p>
+
+        <p>
+          <small>
+            <span class="mono">apt install fish</span>
+          </small>
         </p>
       </div>
 


### PR DESCRIPTION
Earlier, installation instruction for Debian distribution pointing to
Opensuse package download page, which is now replaced with Debian's
package trackers page; and add an instruction to install "fish" shell
directly from Debian's official repository.