### PR TITLE
Update site to Bootstrap 4.6

### DIFF
--- a/site/assets/css/fish_style.css
+++ b/site/assets/css/fish_style.css
@@ -481,7 +481,7 @@ h3 {
 }
 
 /* On narrow screens remove the gradient around the content */
-@media screen and (max-width: 900px) {
+@media screen and (max-width: 1000px) {
     body.gradient_body {
         margin: 0;
         padding: 0;

--- a/site/assets/css/fish_style.css
+++ b/site/assets/css/fish_style.css
@@ -1,3 +1,8 @@
+*, ::after, ::before {
+    /* Bootstrap messes with this */
+    box-sizing: content-box;
+}
+
 body.tutorial_body {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 13pt;
@@ -128,6 +133,26 @@ ul li {
 
 .nav-tabs {
     margin-bottom: 0;
+}
+
+.nav-tabs .nav-item.show .nav-link, .nav-tabs .nav-link.active {
+    color: #495057;
+    background-color: #fff;
+    border-color: #dee2e6 #dee2e6 #fff;
+}
+.nav-tabs .nav-link {
+    margin-bottom: -1px;
+    border: 1px solid transparent;
+        border-top-color: transparent;
+        border-right-color: transparent;
+        border-bottom-color: transparent;
+        border-left-color: transparent;
+    border-top-left-radius: .25rem;
+    border-top-right-radius: .25rem;
+}
+.nav-link {
+    display: block;
+    padding: .5rem 1rem;
 }
 
 .mono {
@@ -371,6 +396,8 @@ h3 {
 
 .jumbotron {
     margin: 36px 0;
+    padding: 0;
+    background-color: inherit;
 }
 
 .jumbotron h1 {
@@ -492,4 +519,19 @@ h3 {
         margin: 0;
         width: auto;
     }
+}
+
+.nav-tabs > li {
+    margin-bottom: -1px;
+}
+
+.btn-large {
+    font-size: larger;
+    background-color: #222;
+    background: linear-gradient(rgb(255, 255, 255) 0%, rgb(230, 230, 230) 100%)
+}
+
+.btn {
+    border-color: #c5c5c5;
+    border-color: rgba(0,0,0,0.15) rgba(0,0,0,0.15) rgba(0,0,0,0.25);
 }

--- a/site/assets/css/fish_style.css
+++ b/site/assets/css/fish_style.css
@@ -8,6 +8,13 @@ img {
     max-width: 100%;
 }
 
+.h4, h4 {
+    font-size: unset;
+}
+.h1, .h2, .h3, .h4, .h5, .h6, h1, h2, h3, h4, h5, h6 {
+    font-weight: bold;
+}
+
 body.tutorial_body {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 13pt;

--- a/site/assets/css/fish_style.css
+++ b/site/assets/css/fish_style.css
@@ -3,6 +3,11 @@
     box-sizing: content-box;
 }
 
+img {
+    height: auto;
+    max-width: 100%;
+}
+
 body.tutorial_body {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 13pt;

--- a/site/assets/css/fish_style.css
+++ b/site/assets/css/fish_style.css
@@ -436,6 +436,29 @@ h3 {
     color: rgb(0, 85, 128);
 }
 
+.btn:hover {
+    text-decoration: none;
+    background-position: 0 -15px;
+    -webkit-transition: background-position .1s linear;
+    -moz-transition: background-position .1s linear;
+    -o-transition: background-position .1s linear;
+    transition: background-position .1s linear;
+}
+
+.btn:hover, .btn:active, .btn.active, .btn.disabled, .btn[disabled] {
+    color: #333;
+    background-color: #e6e6e6;
+    background-image: unset;
+    *background-color: #d9d9d9;
+}
+a:hover {
+    color: #005580;
+    text-decoration: underline;
+}
+a:hover, a:active {
+    outline: 0;
+}
+
 .app-download {
     width: 110px;
     height: 110px;

--- a/site/index.html
+++ b/site/index.html
@@ -10,7 +10,7 @@ title: fish shell
   <meta name="viewport" content="width=920">
   <meta name="description" content="A smart and user-friendly command line shell">
   <meta name="author" content="ridiculous_fish">
-  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/2.2.2/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
   <link href="assets/css/fish_style.css" rel="stylesheet" type="text/css">
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!--[if lt IE 9]>
@@ -148,11 +148,11 @@ title: fish shell
   <h3>Go fish</h3>
 
   <ul id="platform_tabs" class="nav nav-tabs">
-    <li class="active"><a href="#get_fish_osx" data-toggle="tab">macOS</a></li>
-    <li><a href="#get_fish_linux" data-toggle="tab">Linux</a></li>
-    <li><a href="#get_fish_bsd" data-toggle="tab">BSD</a></li>
-    <li><a href="#get_fish_windows" data-toggle="tab">Windows</a></li>
-    <li><a href="#get_fish_source" data-toggle="tab">Sources</a></li>
+    <li class="active"><a href="#get_fish_osx" class="nav-link" data-toggle="tab">macOS</a></li>
+    <li><a href="#get_fish_linux" class="nav-link" data-toggle="tab">Linux</a></li>
+    <li><a href="#get_fish_bsd" class="nav-link" data-toggle="tab">BSD</a></li>
+    <li><a href="#get_fish_windows" class="nav-link" data-toggle="tab">Windows</a></li>
+    <li><a href="#get_fish_source" class="nav-link" data-toggle="tab">Sources</a></li>
   </ul>
 
   <div class="tab-content download_tabs over-pos">
@@ -615,8 +615,9 @@ title: fish shell
   </ul>
 </div>
 
-<script src="https://code.jquery.com/jquery-1.9.0.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/2.2.2/js/bootstrap.min.js" type="text/javascript"></script>
+<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-Piv4xVNRyMGpqkS2by6br4gNJ7DXjqk09RmUpJ8jgGtD7zP9yug3goQfGII0yAns" crossorigin="anonymous"></script>
+
 
 <script type="text/javascript">
   $(function () {


### PR DESCRIPTION
This is still not entirely the current version, but at least not
2.2.2.

There are some minor visual changes - the fonts aren't as fat anymore,
I *think* there's some differences in the tab border.

I like the font changes and don't really think the rest is important.

## Screenshots

Note: The gradient around the main body *works* on the actual site, that's an artifact of firefox' screenshot function.

### Before

![Screenshot 2021-06-03 at 11-57-04 fish shell](https://user-images.githubusercontent.com/5185367/120626352-e0114780-c462-11eb-851f-2e42c3bf33b5.png)

### After

![Screenshot 2021-06-03 at 11-56-49 fish shell](https://user-images.githubusercontent.com/5185367/120626378-e69fbf00-c462-11eb-9c8f-68b6ebbef794.png)
