### PR TITLE
Entirely remove Bootstrap and JQuery

### DIFF
--- a/site/assets/css/fish_style.css
+++ b/site/assets/css/fish_style.css
@@ -1,3 +1,151 @@
+/* BEGIN bootstrap nick */
+/* MIT License applies to this block */
+body {
+    line-height: 20px;
+}
+
+img {
+    max-width: 100%;
+    border: 0;
+}
+
+h1 {
+    font-size: 38.5px;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    margin: 10px 0;
+    font-family: inherit;
+    font-weight: bold;
+    color: inherit;
+    text-rendering: optimizelegibility;
+}
+
+h3 {
+    font-size: 24.5px;
+}
+
+h1, h2, h3 {
+    line-height: 40px;
+}
+
+.lead {
+    font-size: 21px;
+}
+
+p {
+    margin: 0 0 10px;
+}
+
+hr {
+    border: 0;
+}
+
+
+.btn {
+    border-color: #c5c5c5;
+    border-color: rgba(0,0,0,0.15) rgba(0,0,0,0.15) rgba(0,0,0,0.25);
+}
+
+.btn-large {
+    padding: 11px 19px;
+    font-size: 17.5px;
+    border-radius: 6px;
+}
+
+.btn {
+    display: inline-block;
+    margin-bottom: 0;
+    font-size: 14px;
+    line-height: 20px;
+    color: #333;
+    text-align: center;
+    text-shadow: 0 1px 1px rgba(255,255,255,0.75);
+    vertical-align: middle;
+    cursor: pointer;
+    background-color: #f5f5f5;
+    background-image: linear-gradient(to bottom,#fff,#e6e6e6);
+    background-repeat: repeat-x;
+    border: 1px solid #bbb;
+    border-color: rgba(0,0,0,0.1) rgba(0,0,0,0.1) rgba(0,0,0,0.25);
+    border-bottom-color: #a2a2a2;
+    border-radius: 4px;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.05);
+}
+
+a, label {
+    color: #08c;
+    text-decoration: none;
+}
+
+.btn:hover {
+    text-decoration: none;
+    background-position: 0 -15px;
+    transition: background-position .1s linear;
+}
+
+.btn:hover, .btn:active, .btn.active, .btn.disabled, .btn[disabled] {
+    color: #333;
+    background-color: #e6e6e6;
+    background-image: unset;
+}
+
+a:hover {
+    color: #005580;
+    text-decoration: underline;
+}
+
+a:hover, a:active {
+    outline: 0;
+}
+
+.nav {
+    margin-bottom: 20px;
+    margin-left: 0;
+    list-style: none;
+}
+
+ul, ol {
+    padding: 0;
+    margin: 0 0 10px 25px;
+        margin-bottom: 10px;
+        margin-left: 25px;
+}
+
+.nav-tabs > li {
+    margin-bottom: -1px;
+}
+
+.nav-tabs > li > label {
+    cursor: pointer;
+    padding-top: 12px;
+    padding-bottom: 8px;
+    line-height: 20px;
+    border: 1px solid transparent;
+    border-radius: 4px 4px 0 0;
+}
+
+.nav-tabs > li > label, .nav-pills > li > label {
+    padding-right: 12px;
+    padding-left: 12px;
+    margin-right: 2px;
+    line-height: 14px;
+}
+
+.nav > li > label {
+    display: block;
+}
+
+.nav-tabs > li > label:hover {
+    border-color: #eee #eee #ddd;
+}
+
+.nav > li > label:hover {
+    text-decoration: none;
+    background-color: #eee;
+}
+/* END bootstrap nick */
+
 body.tutorial_body {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 13pt;
@@ -33,6 +181,8 @@ body.gradient_body {
 
 #platform_tabs {
     font-weight: bold;
+    display: flex;
+    flex-direction: row;
 }
 
 .download_tabs {
@@ -492,4 +642,38 @@ h3 {
         margin: 0;
         width: auto;
     }
+}
+
+.download_tab {
+    display: none;
+}
+
+#tab1:checked ~ ul.nav-tabs li label.tab1,
+#tab2:checked ~ ul.nav-tabs li label.tab2,
+#tab3:checked ~ ul.nav-tabs li label.tab3,
+#tab4:checked ~ ul.nav-tabs li label.tab4,
+#tab5:checked ~ ul.nav-tabs li label.tab5
+{
+    background-color: #FFF;
+    border: 1px solid black;
+    color: #555;
+    cursor: default;
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-bottom-color: rgb(221, 221, 221);
+    border-bottom-color: transparent;
+}
+
+/* This is cheesy - hardcode which tab input applies to which tab. */
+#tab1:checked ~ div div#get_fish_osx,
+#tab2:checked ~ div div#get_fish_linux,
+#tab3:checked ~ div div#get_fish_bsd,
+#tab4:checked ~ div div#get_fish_windows,
+#tab5:checked ~ div div#get_fish_source
+{
+    display: block;
+}
+
+input.tabselector {
+    display: none;
 }

--- a/site/index.html
+++ b/site/index.html
@@ -10,21 +10,12 @@ title: fish shell
   <meta name="viewport" content="width=920">
   <meta name="description" content="A smart and user-friendly command line shell">
   <meta name="author" content="ridiculous_fish">
-  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/2.2.2/css/bootstrap.min.css" rel="stylesheet" type="text/css">
   <link href="assets/css/fish_style.css" rel="stylesheet" type="text/css">
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!--[if lt IE 9]>
   <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
   <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
   <![endif]-->
-  <noscript>
-    <style type="text/css">
-      /* Show all tabs when JS is disabled */
-      .tab-content > .tab-pane, .pill-content > .pill-pane { display: block }
-      #platform_tabs { display: none }
-    </style>
-  </noscript>
-
 </head>
 
 <body class="gradient_body">
@@ -147,12 +138,19 @@ title: fish shell
 
   <h3>Go fish</h3>
 
+  <!-- These are fake radiobuttons triggered by clicking on the *label*,
+       some css then displays the selected tab and marks the label active -->
+  <input class="tabselector" name="tabselector" type="radio" id="tab1">
+  <input class="tabselector" name="tabselector" type="radio" id="tab2">
+  <input class="tabselector" name="tabselector" type="radio" id="tab3">
+  <input class="tabselector" name="tabselector" type="radio" id="tab4">
+  <input class="tabselector" name="tabselector" type="radio" id="tab5" checked>
   <ul id="platform_tabs" class="nav nav-tabs">
-    <li class="active"><a href="#get_fish_osx" data-toggle="tab">macOS</a></li>
-    <li><a href="#get_fish_linux" data-toggle="tab">Linux</a></li>
-    <li><a href="#get_fish_bsd" data-toggle="tab">BSD</a></li>
-    <li><a href="#get_fish_windows" data-toggle="tab">Windows</a></li>
-    <li><a href="#get_fish_source" data-toggle="tab">Sources</a></li>
+    <li><label for="tab1" class="tab1">macOS</label></li>
+    <li><label for="tab2" class="tab2">Linux</label></li>
+    <li><label for="tab3" class="tab3">BSD</label></li>
+    <li><label for="tab4" class="tab4">Windows</label></li>
+    <li><label for="tab5" class="tab5">Sources</label></li>
   </ul>
 
   <div class="tab-content download_tabs over-pos">
@@ -615,11 +613,8 @@ title: fish shell
   </ul>
 </div>
 
-<script src="https://code.jquery.com/jquery-1.9.0.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/2.2.2/js/bootstrap.min.js" type="text/javascript"></script>
-
 <script type="text/javascript">
-  $(function () {
+  (function () {
     // Show correct tab
 
     var plat = navigator.platform.toUpperCase();
@@ -628,19 +623,19 @@ title: fish shell
     var isBSD = plat.indexOf('BSD') !== -1;
     var isWindows = plat.indexOf('WINDOWS') !== -1;
 
-    var which = 'get_fish_source';
+    var which = 'tab5';
     if (isMac) {
-      which = 'get_fish_mac'
+      which = 'tab1';
     } else if (isLinux) {
-      which = 'get_fish_linux';
+      which = 'tab2';
     } else if (isBSD) {
-      which = 'get_fish_bsd';
+      which = 'tab3';
     } else if (isWindows) {
-      which = 'get_fish_windows';
+      which = 'tab4';
     }
 
-    $('#platform_tabs').find('a[href="#' + which + '"]').tab('show');
-  });
+    document.querySelector("#" + which).checked = true;
+  })();
 </script>
 
 </body>


### PR DESCRIPTION
This replaces Bootstrap with our own "solution".

We only used it for two things:

- Some very minor CSS that we could also change
- The "Download Fish" tab menu

The latter used javascript to select the tab, and fell back to
displaying *all platforms* if js was disabled.

We replace it with a CSS solution based on hidden radiobuttons
triggered by labels and some :checked magic. The entire menu now runs
without javascript, it's only necessary at start to select the current
platform - now it will fall back to selecting "Sources", and the
user'll have to select their platform (but they can!)

As to the CSS I've copied the most important parts, there are some
miniscule rendering differences - a pixel here and there, but nothing
noticeable unless you're switching back and forth side-by-side.

The button hover effect has been replaced with a simpler one, so
they'll just be a flat grey instead of a barely visible gradient.

## Screenshots

### New

![Screenshot 2021-06-03 at 11-57-04 fish shell](https://user-images.githubusercontent.com/5185367/120825781-05cd4800-c55a-11eb-911b-a0c87feb39cc.png)

![Screenshot_20210604_172433](https://user-images.githubusercontent.com/5185367/120825715-f3eba500-c559-11eb-942d-4ceca875797e.png)

### Old

![Screenshot 2021-06-03 at 11-57-04 fish shell](https://user-images.githubusercontent.com/5185367/120826006-462cc600-c55a-11eb-9702-e893bc06b9f3.png)


![Screenshot_20210604_172450](https://user-images.githubusercontent.com/5185367/120825741-f9e18600-c559-11eb-8cac-835cfc971147.png)


### Note:

This also removes some quite obsolete compatibility cludges like "-webkit-border-radius" and background-color without rgba. I confirmed with https://caniuse.com that these are very well supported (~98% of global users)


----

Obsoletes #100 