### PR TITLE
Fix Guix package link

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1,4 +1,4 @@
----
+x---
 title: fish shell
 ---
 {%- assign release = site.data.releases | first %}
@@ -364,11 +364,10 @@ title: fish shell
       </div>
       <div>
         <p>
-          <img class="logofix" src="assets/img/guix_icon.svg" alt="GNU Guix and GuixSD">
+          <img class="logofix" src="assets/img/guix_icon.svg" alt="GNU Guix">
         </p>
         <p>
-	  <!-- A better Guix packages page is in the works. For now, use: -->
-          <a href="https://guix.gnu.org/packages/fish-3.0.2/">Packages</a>
+          <a href="https://packages.guix.gnu.org/packages/fish/">Packages</a>
         </p>
 
         <p>


### PR DESCRIPTION
The better Guix package page mentioned in the comment has arrived!  Also, the Guix project doesn't refer to the OS as GuixSD anymore, so I dropped that from the alt-text.