### PR TITLE
Update installation instruction for Linux distros

### DIFF
--- a/docs/docs/3.6/_static/pydoctheme.css
+++ b/docs/docs/3.6/_static/pydoctheme.css
@@ -552,10 +552,6 @@ aside.footnote > p {
     line-height: 1.5em;
 }
 
-div.documentwrapper {
-    width: 100%;
-}
-
 /* On screens that are less than 700px wide remove anything non-essential
    - the sidebar, the gradient background, ... */
 @media screen and (max-width: 700px) {

--- a/docs/docs/current/_static/pydoctheme.css
+++ b/docs/docs/current/_static/pydoctheme.css
@@ -552,10 +552,6 @@ aside.footnote > p {
     line-height: 1.5em;
 }
 
-div.documentwrapper {
-    width: 100%;
-}
-
 /* On screens that are less than 700px wide remove anything non-essential
    - the sidebar, the gradient background, ... */
 @media screen and (max-width: 700px) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -241,8 +241,15 @@
         </p>
 
         <p>
-          <a href="https://launchpad.net/~fish-shell/+archive/ubuntu/release-3">Subscribe</a> or <a
-          href="https://launchpad.net/~fish-shell/+archive/ubuntu/release-3/+packages">Download</a>
+          <a href="https://packages.ubuntu.com/search?keywords=fish&searchon=names&suite=all&section=all">
+            Packages
+          </a>
+        </p>
+
+        <p>
+          <small>
+            <span class="mono">apt install fish</span>
+          </small>
         </p>
       </div>
 
@@ -252,9 +259,15 @@
         </p>
 
         <p>
-          <a href="https://software.opensuse.org/download.html?project=shells%3Afish%3Arelease%3A3&package=fish">
-            Subscribe or Download
+          <a href="https://packages.debian.org/search?keywords=fish&searchon=names&suite=all&section=all">
+            Packages
           </a>
+        </p>
+
+        <p>
+          <small>
+            <span class="mono">apt install fish</span>
+          </small>
         </p>
       </div>
 
@@ -280,9 +293,14 @@
         </p>
 
         <p>
-          <a href="https://software.opensuse.org/download.html?project=shells%3Afish%3Arelease%3A3&package=fish">
-            Subscribe or Download
-          </a>
+          <a href="https://packagehub.suse.com/packages/fish/">Leap</a> or
+          <a href="https://software.opensuse.org/package/fish">Tumbleweed</a>
+        </p>
+
+        <p>
+          <small>
+            <span class="mono">zypper install fish</span>
+          </small>
         </p>
       </div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -244,8 +244,15 @@ title: fish shell
         </p>
 
         <p>
-          <a href="https://launchpad.net/~fish-shell/+archive/ubuntu/release-3">Subscribe</a> or <a
-          href="https://launchpad.net/~fish-shell/+archive/ubuntu/release-3/+packages">Download</a>
+          <a href="https://packages.ubuntu.com/search?keywords=fish&searchon=names&suite=all&section=all">
+            Packages
+          </a>
+        </p>
+
+        <p>
+          <small>
+            <span class="mono">apt install fish</span>
+          </small>
         </p>
       </div>
 
@@ -255,9 +262,15 @@ title: fish shell
         </p>
 
         <p>
-          <a href="https://software.opensuse.org/download.html?project=shells%3Afish%3Arelease%3A3&package=fish">
-            Subscribe or Download
+          <a href="https://packages.debian.org/search?keywords=fish&searchon=names&suite=all&section=all">
+            Packages
           </a>
+        </p>
+
+        <p>
+          <small>
+            <span class="mono">apt install fish</span>
+          </small>
         </p>
       </div>
 
@@ -283,9 +296,14 @@ title: fish shell
         </p>
 
         <p>
-          <a href="https://software.opensuse.org/download.html?project=shells%3Afish%3Arelease%3A3&package=fish">
-            Subscribe or Download
-          </a>
+          <a href="https://packagehub.suse.com/packages/fish/">Leap</a> or
+          <a href="https://software.opensuse.org/package/fish">Tumbleweed</a>
+        </p>
+
+        <p>
+          <small>
+            <span class="mono">zypper install fish</span>
+          </small>
         </p>
       </div>
 


### PR DESCRIPTION
A simple update of links and addition of installation instructions for Debian, Ubuntu, and openSUSE Leap and Tumbleweed.

---

![image](https://user-images.githubusercontent.com/31497094/232679970-0a13e1d5-947b-4f16-8765-df0ea0aa7d81.png)
