### PR TITLE
Avoid awkward rounding

### DIFF
--- a/site/assets/css/fish_style.css
+++ b/site/assets/css/fish_style.css
@@ -163,6 +163,10 @@ body.gradient_body {
     border-radius: 5px;
 }
 
+#tab1:is(:hover, :checked) ~ .download_tabs {
+    border-radius: 0 5px 5px 5px;
+}
+
 .over-pos {
     overflow: visible;
     position: relative;


### PR DESCRIPTION
Before:

<img width="290" alt="Screenshot 2023-07-28 at 23 08 56" src="https://github.com/fish-shell/fish-site/assets/36937807/5a3b8952-31e9-478a-9c01-a9053c68781b">

<img width="103" alt="Screenshot 2023-07-28 at 22 44 36" src="https://github.com/fish-shell/fish-site/assets/36937807/0aacf4b3-fb16-466c-88d7-b100732c8a10">

After:
<img width="347" alt="Screenshot 2023-07-28 at 23 06 59" src="https://github.com/fish-shell/fish-site/assets/36937807/f19e0bea-03bd-4fbd-9883-29a7e0283c22">

<img width="326" alt="Screenshot 2023-07-28 at 23 07 04" src="https://github.com/fish-shell/fish-site/assets/36937807/7aa00e51-1527-48ea-bb0b-27a47455733f">


It could be argued that the white background should instead  extend down in the `:hover`-case, but that is more work to implement and this looks nice enough