### PR TITLE
add correct debian link and installation instructions

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -244,8 +244,8 @@ title: fish shell
         </p>
 
         <p>
-          <a href="https://software.opensuse.org/download.html?project=shells%3Afish%3Arelease%3A3&package=fish">
-            Subscribe or Download
+          <a href="https://packages.debian.org/sid/fish">
+            apt install fish
           </a>
         </p>
       </div>


### PR DESCRIPTION
Debian distributes fish and it should be installed that way - there's no need to add opensuse repos. Don't teach new users bad habits :)

[It's been part of the debian repo since at least Buster.](https://packages.debian.org/buster/fish)