### PR TITLE
fix: fix typo on 2024-12-1-fish-4b.md

### DIFF
--- a/site/_posts/2024-12-1-fish-4b.md
+++ b/site/_posts/2024-12-1-fish-4b.md
@@ -17,7 +17,7 @@ fish 4.0 is a big upgrade. It's got lots of new features to make using the comma
 You can get the beta in the following ways:
 * Packages for macOS from the [GitHub release page](https://github.com/fish-shell/fish-shell/releases/tag/4.0b1)
 * Using Homebrew on macOS: `brew install fish-shell/fish-beta-4/fish`
-* Using our PPA for Ubuntu: `sudo add-apt-repository ppa:fish-shell/beta-4; sudo install fish`
+* Using our PPA for Ubuntu: `sudo add-apt-repository ppa:fish-shell/beta-4; sudo apt install fish`
 * Using [prebuilt packages for other Linux distributions](https://software.opensuse.org//download.html?project=shells%3Afish%3Abeta%3A4&package=fish)
 * Using the portable binaries for Linux from the [GitHub release page](https://github.com/fish-shell/fish-shell/releases/tag/4.0b1)
 


### PR DESCRIPTION
This simply fixes a small typo in the article: `sudo install fish` → `sudo apt install fish`