### PR TITLE
Enable mobile support for blog

### DIFF
--- a/site/_layouts/post.html
+++ b/site/_layouts/post.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <title>{{ page.title }}</title>
-  <meta name="viewport" content="width=920">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <meta name="description" content="A smart and user-friendly command line shell">
   <link href="https://maxcdn.bootstrapcdn.com/bootstrap/2.2.2/css/bootstrap.min.css" rel="stylesheet" type="text/css">
   <link href="{{ base }}/assets/css/fish_style.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
I got excited about the Rust work but the blog about it was unreadable on my phone. This will fix it.

The main site uses the same meta viewport already.