### PR TITLE
Wrap whitespace in `<code>` text on narrow screens

### DIFF
--- a/site/assets/css/fish_style.css
+++ b/site/assets/css/fish_style.css
@@ -476,6 +476,10 @@ h3 {
         float: none;
         margin: 0 auto 0;
     }
+
+    code {
+	white-space: pre-wrap;
+    }
 }
 
 .download_tab {


### PR DESCRIPTION
On relatively narrow screens (noticed this on my iPhone 11), the non-wrapping text in `<code>` tags becomes wider than the document body, leading to an unreasobly zoomed-out view of the website when viewing it in the iOS Chrome app.

In Safari, the initial zoom is correct, but the `<code>` tag content is still wider than the body, resulting in the same empty space taking up half of the website's width.

This leads to a somewhat irritating experience when using the website, as a user has to zoom in to actually have the blog post content utilise the full screen. A Safari user might not notice this issue immediately, but on scroll or when they get to the `code` content, it will likely become apparent that the empty space is there.

While I understand why text within `<code>` tags is not wrapped (this is defined in [the included bootstrap stylesheet](https://github.com/fish-shell/fish-site/blob/2f6d06c89e1a72d004fa643fbccf5baa21c15f49/site/_layouts/post.html#L9), by the way), I believe that, especially in the context of a blog, the overall reading experience of the website should be a higher priority than keeping whitespace in code correctly formatted.

## Alternative

Another possible fix would be to use similar formatting to the `<pre>` tags used in /docs, which become horizontally scrollable if they would otherwise overflow the viewport.

Let me know if you would prefer this, I wouldn't mind taking a look at it.

## Screenshots

### Blog post page in iOS Chrome (iPhone 11)

![ios-chrome](https://github.com/user-attachments/assets/4c56fc92-9253-4b15-bc46-42545a38cfb3)

### Blog post page in iOS Safari (iPhone 11)
_The empty space is still there, just not visible on the first load because of the initial zoom_

![ios-safari](https://github.com/user-attachments/assets/e6dd97ab-f833-45c9-a32a-ca57fb48d842)

### Problematic section in desktop Chrome

![before](https://github.com/user-attachments/assets/e0741ff4-7fd7-40df-ba25-9bf78dde64f5)

### Problematic section in desktop Chrome, after this PR's changes

![after-pre-wrap](https://github.com/user-attachments/assets/ad8afbcc-f324-4b34-a47f-679b4417695d)