### PR TITLE
Change minimum macOS version to 10.12+

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -200,7 +200,7 @@
 
         <p>
           <small>
-            10.9+, Intel or Apple silicon<br>
+            10.12+, Intel or Apple silicon<br>
             Installs to <span class="mono">/usr/local/</span>
           </small>
         </p>
@@ -219,7 +219,7 @@
 
         <p>
           <small>
-            10.9+, Intel or Apple silicon
+            10.12+, Intel or Apple silicon
             <br>
             <a href="#" onclick="document.getElementById('app_explanation').style.display = 'block'; return false;">
               No installation required

--- a/site/index.html
+++ b/site/index.html
@@ -203,7 +203,7 @@ title: fish shell
 
         <p>
           <small>
-            10.9+, Intel or Apple silicon<br>
+            10.12+, Intel or Apple silicon<br>
             Installs to <span class="mono">/usr/local/</span>
           </small>
         </p>
@@ -222,7 +222,7 @@ title: fish shell
 
         <p>
           <small>
-            10.9+, Intel or Apple silicon
+            10.12+, Intel or Apple silicon
             <br>
             <a href="#" onclick="document.getElementById('app_explanation').style.display = 'block'; return false;">
               No installation required


### PR DESCRIPTION
This corrects the description for the macOS downloads from 10.9+ to 10.12+. It might also be worth mentioning that fish 4.1.2 is the last version that works on 10.11 El Capitan and older, but I'm not sure on how to add that in here.